### PR TITLE
Force the base for an exponent to be positive.

### DIFF
--- a/questions/reverseTracingExpression3/server.py
+++ b/questions/reverseTracingExpression3/server.py
@@ -25,7 +25,7 @@ def generate(data):
     
     a = single_digit_number()
     b = single_digit_number()
-    if 'exponent' in template[1] and version == 1 and b < 0:
+    if 'exponent' in template[1] and b < 0:
         b = -b
     c = random.randint(2, 4)
     expr_str = template[0].format(a, b, c)


### PR DESCRIPTION
While `9 + -4 ** 2` does evaluate to `-7` in Python, it is surprising that the expression is interpreted as `9 + -(4 ** 2)` rather than `9 + (-4) ** 2`. Unless we are actually trying to teach this, it seems better to stick with positive numbers for the middle integer literal.